### PR TITLE
build: Added basic makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+BINARIES = false \
+					 true 
+
+all: $(BINARIES)
+
+$(BINARIES):
+	go build -o bin $@/$@.go


### PR DESCRIPTION
Adds a simple Makefile.  For now, you need to compile with ``make -B``.

To add more sub-directories/binaries, just add to the BINARIES variable.